### PR TITLE
Refine punctuation normalization for mixed language text

### DIFF
--- a/tests/test_text_clean.py
+++ b/tests/test_text_clean.py
@@ -1,0 +1,30 @@
+import unittest
+
+from modules.text_clean import normalize_punct
+
+
+class NormalizePunctTestCase(unittest.TestCase):
+    def test_cjk_sentence_uses_chinese_punct(self):
+        self.assertEqual(normalize_punct("这是中文.", "zh"), "这是中文。")
+
+    def test_latin_segment_keeps_ascii_period(self):
+        self.assertEqual(normalize_punct("This is english.", "zh"), "This is english.")
+
+    def test_mixed_sentence_keeps_latin_punct(self):
+        self.assertEqual(normalize_punct("测试 test.", "zh"), "测试 test.")
+
+    def test_cjk_punct_with_space(self):
+        self.assertEqual(normalize_punct("你好 !", "zh"), "你好 ！")
+
+    def test_leading_punct_followed_by_cjk(self):
+        self.assertEqual(normalize_punct("?你好", "zh"), "？你好")
+
+    def test_semicolon_conversion_for_cjk(self):
+        self.assertEqual(normalize_punct("你好;", "zh"), "你好；")
+
+    def test_semicolon_kept_for_latin(self):
+        self.assertEqual(normalize_punct("Example; text", "zh"), "Example; text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update punctuation normalization to only convert ASCII punctuation when adjacent to CJK characters
- add helpers for detecting CJK context while preserving Latin segments
- add unit tests covering mixed-language punctuation handling, including semicolons

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ce46878528832abc54bd8c0676f820