### PR TITLE
Disable Whisper conditioning on previous transcript text

### DIFF
--- a/asr_worker.py
+++ b/asr_worker.py
@@ -174,7 +174,7 @@ def _process_task(task_id: str):
             vad_filter=True,
             word_timestamps=True,
             initial_prompt=ctx_prompt,
-            condition_on_previous_text=True,
+            condition_on_previous_text=False,
             temperature=0.0,
         )
 


### PR DESCRIPTION
## Summary
- disable Whisper's conditioning on previous text so each segment can re-detect language independently

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce598ecaf4832a8a9cdb26c2073320